### PR TITLE
Fix traceback when stop command is executed

### DIFF
--- a/functions/tool/music.py
+++ b/functions/tool/music.py
@@ -98,8 +98,11 @@ class MusicCog(commands.Cog):
 
     def _play_next(self, guild_id: int, error=None):
         if error:
-            print(f"Player error: {error}")
+            print(f"Player error for guild {guild_id}: {error}")
 
+        if (guild_id not in self.voice_clients or not self.voice_clients[guild_id].is_connected()):
+            return
+        
         if guild_id in self.queues and self.queues[guild_id]:
             url, title = self.queues[guild_id].pop(0)
             self._play_song(guild_id, url, title)


### PR DESCRIPTION
# Pull Request

## Description
Issue fixed when someone has music playing and they run the command stop. The bot will leave accordingly but will suddenly stop and show a traceback error on the bot's logging system.

## Related Issue(s)
No related issues as of now.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring or optimization
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have tested my changes locally
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)
- [x] I have added tests to cover my changes (if applicable)