### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,5 +1,9 @@
 name: Publish Docker Image
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,6 @@ config.py
 # ignore migration files used as DB
 mi.md
 mi.mhtml
+
+# SQLite databases
+data/*.sqlite

--- a/functions/tool/nintendo.py
+++ b/functions/tool/nintendo.py
@@ -1,0 +1,87 @@
+from typing import TYPE_CHECKING, Optional
+from re import fullmatch
+from os import makedirs, path
+from aiosqlite import connect
+from discord import Interaction, app_commands
+from discord.ext import commands
+
+if TYPE_CHECKING:
+    from main import UiPy
+
+
+class NintendoCog(commands.Cog):
+    """Cog for Nintendo Switch Friend Code linking and sharing."""
+    def __init__(self, bot: "UiPy"):
+        self.bot = bot
+        self.db_path = "data/nintendo_links.sqlite"
+
+    async def cog_load(self):
+        await self._init_db()
+
+    async def _init_db(self):
+        makedirs(path.dirname(self.db_path), exist_ok=True)
+        async with connect(self.db_path) as db:
+            await db.execute("""
+                CREATE TABLE IF NOT EXISTS nintendo_links (
+                    discord_id INTEGER PRIMARY KEY,
+                    friend_code TEXT NOT NULL
+                )
+            """)
+            await db.commit()
+
+    async def _save_nintendo_link(self, discord_id: int, friend_code: str):
+        async with connect(self.db_path) as db:
+            await db.execute(
+                "INSERT OR REPLACE INTO nintendo_links (discord_id, friend_code) VALUES (?, ?)",
+                (discord_id, friend_code)
+            )
+            await db.commit()
+
+    async def _get_nintendo_link(self, discord_id: int) -> Optional[str]:
+        async with connect(self.db_path) as db:
+            async with db.execute("SELECT friend_code FROM nintendo_links WHERE discord_id = ?", (discord_id,)) as cursor:
+                if row := await cursor.fetchone():
+                    return row[0]
+                return None
+
+    def _validate_friend_code(self, friend_code: str) -> bool:
+        """Validate Nintendo Switch Friend Code format: SW-####-####-####"""
+        return bool(fullmatch(r"SW-\d{4}-\d{4}-\d{4}", friend_code.upper()))
+
+    @app_commands.command(name="link", description="Link your Discord account to a Nintendo Switch Friend Code.")
+    async def link_nintendo(self, interaction: Interaction, friend_code: str):
+        await interaction.response.defer(ephemeral=True)
+        
+        # Clean and validate the friend code
+        cleaned_code = friend_code.strip().upper()
+        
+        if not self._validate_friend_code(cleaned_code):
+            await interaction.followup.send(
+                ":x: Invalid Friend Code format. Please use the format: `SW-####-####-####`\n"
+                "Example: `SW-1234-5678-9012`"
+            )
+            return
+        
+        await self._save_nintendo_link(interaction.user.id, cleaned_code)
+        await interaction.followup.send(
+            f":white_check_mark: Your Discord account has been successfully linked to Nintendo Friend Code: `{cleaned_code}`."
+        )
+
+    @app_commands.command(name="share", description="Share your linked Nintendo Switch Friend Code.")
+    async def share_nintendo(self, interaction: Interaction):
+        await interaction.response.defer()
+        
+        if not (linked_friend_code := await self._get_nintendo_link(interaction.user.id)):
+            await interaction.followup.send(
+                ":information_source: You haven't linked a Nintendo Switch Friend Code yet. "
+                "Please use `/link <your_friend_code>` command first."
+            )
+            return
+        
+        await interaction.followup.send(
+            f"Here's my Nintendo Switch Friend ID! `{linked_friend_code}`"
+        )
+
+
+async def setup(bot: "UiPy"):
+    await bot.add_cog(NintendoCog(bot))

--- a/functions/tool/nintendo.py
+++ b/functions/tool/nintendo.py
@@ -74,7 +74,7 @@ class NintendoCog(commands.Cog):
         if not (linked_nintendo_id := await self._get_nintendo_link(interaction.user.id)):
             await interaction.followup.send(
                 ":information_source: You haven't linked a Nintendo Switch Friend Code yet. "
-                "Please use `/link <your_nintendo_id>` command first."
+                "Please use `/link-nintendo <your_nintendo_id>` command first."
             )
             return
         

--- a/functions/tool/steam.py
+++ b/functions/tool/steam.py
@@ -4,7 +4,6 @@ from os import environ, makedirs, path
 from aiosqlite import connect
 from discord import Interaction, app_commands, Embed
 from discord.ext import commands
-import traceback
 
 if TYPE_CHECKING:
     from main import UiPy
@@ -20,7 +19,7 @@ class SteamCog(commands.Cog):
     def __init__(self, bot: "UiPy"):
         self.bot = bot
         self.steam_api_base = "https://api.steampowered.com"
-        self.db_path = "data/steam_links.sqlite"
+        self.db_path = "data/ui.sqlite"
 
     async def cog_load(self):
         await self._init_db()
@@ -96,7 +95,7 @@ class SteamCog(commands.Cog):
         # Default return if no resolution
         return None
 
-    @app_commands.command( name="link", description="Link your Discord account to a Steam ID or vanity URL." )
+    @app_commands.command( name="link-steam", description="Link your Discord account to a Steam ID or vanity URL." )
     async def link_steam(self, interaction: Interaction, steam_identifier: str):
         await interaction.response.defer(ephemeral=True)
         


### PR DESCRIPTION
Potential fix for [https://github.com/taichikuji/Ui-Py/security/code-scanning/1](https://github.com/taichikuji/Ui-Py/security/code-scanning/1)

To resolve the issue, add an explicit `permissions` block to the workflow. Since this workflow involves operations like checking out code and pushing Docker images, the required permissions are likely minimal. Grant `contents: read` for code checkout and `packages: write` for pushing Docker images. Apply this permission at the workflow level to cover all jobs consistently unless specific jobs require additional permissions.

Changes will be made to the top-level of the workflow file to include the `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
